### PR TITLE
Make `cwd` of `elm-make` a configurable option

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,7 +25,7 @@ function compile(sources, flags, options) {
   }
 
   if (!(sources instanceof Array)) {
-    throw "compile() received neither an Array nor a String for its sources argument."
+    throw "compile() received neither an Array nor a String for its sources argument.";
   }
 
   var processArgs  = sources ? sources.concat(flags) : flags;
@@ -43,7 +43,7 @@ function compile(sources, flags, options) {
       .on('error', function(err) {
         handleError(pathToMake, err);
 
-        process.exit(1)
+        process.exit(1);
       });
   } catch (err) {
     if ((typeof err === "object") && (typeof err.code === "string")) {
@@ -52,13 +52,13 @@ function compile(sources, flags, options) {
       console.error("Exception thrown when attempting to run Elm compiler " + JSON.stringify(pathToMake) + ":\n" + err);
     }
 
-    process.exit(1)
+    process.exit(1);
   }
 }
 
 function handleError(pathToMake, err) {
   if (err.code === "ENOENT") {
-    console.error("Could not find Elm compiler \"" + pathToMake + "\". Is it installed?")
+    console.error("Could not find Elm compiler \"" + pathToMake + "\". Is it installed?");
   } else if (err.code === "EACCES") {
     console.error("Elm compiler \"" + pathToMake + "\" did not have permission to run. Do you need to give it executable permissions?");
   } else {

--- a/index.js
+++ b/index.js
@@ -14,6 +14,7 @@ var defaultCompilerArgs = {
 var supportedCompilerArgs = _.keys(defaultCompilerArgs);
 var defaultOptions = {
   annotation:  undefined,
+  cwd: undefined,
   pathToMake:  undefined,
   destination: "/elm.js"
 };
@@ -29,7 +30,7 @@ function compile(sources, flags, options) {
 
   var processArgs  = sources ? sources.concat(flags) : flags;
   var env = _.merge({ LANG: 'en_US.UTF-8' }, process.env);
-  var processOpts = { env: env, stdio: ["ignore", "ignore", process.stderr] };
+  var processOpts = { env: env, stdio: ["ignore", "ignore", process.stderr], cwd: options.cwd };
   var pathToMake = options.pathToMake || compilerBinaryName;
   var verbose = options.verbose;
 


### PR DESCRIPTION
This solves an esoteric edge case for me. I use Broccoli across different projects in a monorepo, and I often include one Brocfile within another in order to compose projects. However, this causes `broccoli-elm` to break because the `cwd` of the `child_process.spawn` call is always inherited from the current process, which is not always running within the Elm project directory.

For example:

```
monorepo/
  project1/
    Main.elm
    elm-package.json
    elm-stuff/...
    Brocfile.js
  project2/
    Brocfile.js
```

If the Brocfile in `project1` compiles `Main.elm` and the Brocfile within `project2` calls `require` on the Brocfile within `project1`, then `broccoli-elm` will run using `project2` as `cwd`, not `project1`. This causes the compilation to fail because it can't find `elm-package.json`.

When `cwd` is not set, behaviour remains the same.
